### PR TITLE
Add Ionic-based LoginView with store sync

### DIFF
--- a/restaurant-kiosk/src/views/LoginView.vue
+++ b/restaurant-kiosk/src/views/LoginView.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { IonPage, IonContent, IonInput, IonButton } from '@ionic/vue'
+import { useRouter } from 'vue-router'
+import { useMainStore } from '../store/mainStore'
+
+const email = ref('')
+const password = ref('')
+const store = useMainStore()
+const router = useRouter()
+
+async function onLogin() {
+  try {
+    await store.login(email.value, password.value)
+    await store.syncItems()
+    await store.syncCustomers()
+    router.push('/home')
+  } catch (err) {
+    console.error(err)
+  }
+}
+</script>
+
+<template>
+  <IonPage>
+    <IonContent class="ion-padding">
+      <form @submit.prevent="onLogin" class="flex flex-col gap-4">
+        <IonInput
+          v-model="email"
+          type="email"
+          label="Email"
+          label-placement="floating"
+          required
+        />
+        <IonInput
+          v-model="password"
+          type="password"
+          label="Password"
+          label-placement="floating"
+          required
+        />
+        <IonButton type="submit" expand="block">Login</IonButton>
+      </form>
+    </IonContent>
+  </IonPage>
+</template>
+
+<style scoped>
+form {
+  max-width: 400px;
+  margin: 0 auto;
+}
+</style>
+


### PR DESCRIPTION
## Summary
- add LoginView using Ionic components and `<script setup>`
- login invokes store login then synchronizes items and customers
- route to `/home` after successful authentication

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'axios', '@capacitor-community/sqlite', 'vue-router')*

------
https://chatgpt.com/codex/tasks/task_e_68ab1e827ca8832485178bc3a646aa5c