### PR TITLE
feat: add http interceptor

### DIFF
--- a/restaurant-kiosk/src/__tests__/api.test.ts
+++ b/restaurant-kiosk/src/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import { setActivePinia, createPinia } from 'pinia'
 import { useMainStore } from '../store/mainStore'
 
 vi.mock('../lib/db', () => ({}))
-vi.mock('axios', () => ({
+vi.mock('../lib/http', () => ({
   default: {
     post: vi.fn(),
   },
@@ -11,8 +11,8 @@ vi.mock('axios', () => ({
 
 import { getBaseURL, login } from '../lib/api'
 
-import axios from 'axios'
-const mockedAxios = axios as unknown as { post: ReturnType<typeof vi.fn> }
+import http from '../lib/http'
+const mockedHttp = http as unknown as { post: ReturnType<typeof vi.fn> }
 
 describe('api helpers', () => {
   beforeEach(() => {
@@ -21,18 +21,18 @@ describe('api helpers', () => {
   })
 
   it('getBaseURL returns domain', async () => {
-    mockedAxios.post.mockResolvedValue({ data: { baseURL: 'http://base' } })
+    mockedHttp.post.mockResolvedValue({ data: { baseURL: 'http://base' } })
     const url = await getBaseURL({ email: 'e', password: 'p' })
     expect(url).toBe('http://base')
   })
 
   it('getBaseURL rejects on error', async () => {
-    mockedAxios.post.mockRejectedValue(new Error('fail'))
+    mockedHttp.post.mockRejectedValue(new Error('fail'))
     await expect(getBaseURL({ email: 'e', password: 'p' })).rejects.toThrow('fail')
   })
 
   it('login sets store data', async () => {
-    mockedAxios.post
+    mockedHttp.post
       .mockResolvedValueOnce({ data: { baseURL: 'http://base' } })
       .mockResolvedValueOnce({
         data: { token: 't', locations: [1], settings: { s: true } },
@@ -46,7 +46,7 @@ describe('api helpers', () => {
   })
 
   it('login rejects on failure', async () => {
-    mockedAxios.post
+    mockedHttp.post
       .mockResolvedValueOnce({ data: { baseURL: 'http://base' } })
       .mockRejectedValueOnce(new Error('fail'))
     await expect(login({ email: 'e', password: 'p' })).rejects.toThrow('fail')

--- a/restaurant-kiosk/src/__tests__/http.test.ts
+++ b/restaurant-kiosk/src/__tests__/http.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../lib/db', () => ({}))
+
+import { useMainStore } from '../store/mainStore'
+import { unauthorizedInterceptor, modalController } from '../lib/http'
+
+const mockedModal = {
+  present: vi.fn(),
+  onWillDismiss: vi.fn().mockResolvedValue({}),
+}
+
+describe('http interceptor', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    vi.spyOn(modalController, 'create').mockResolvedValue(mockedModal as any)
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: 'http://localhost/' },
+    })
+  })
+
+  it('resets store and redirects on 401', async () => {
+    const store = useMainStore()
+    store.token = 't'
+    await unauthorizedInterceptor({ response: { status: 401 } }).catch(() => {})
+    expect(store.token).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+})
+

--- a/restaurant-kiosk/src/lib/api.ts
+++ b/restaurant-kiosk/src/lib/api.ts
@@ -1,5 +1,5 @@
-import axios from 'axios'
 import { useMainStore } from '../store/mainStore'
+import http from './http'
 
 interface Credentials {
   email: string
@@ -7,7 +7,7 @@ interface Credentials {
 }
 
 export async function getBaseURL({ email, password }: Credentials): Promise<string> {
-  const { data } = await axios.post('https://app.jakac.com/api/domains', {
+  const { data } = await http.post('https://app.jakac.com/api/domains', {
     email,
     password,
   })
@@ -22,7 +22,7 @@ export async function login({ email, password }: Credentials): Promise<{
   settings: unknown
 }> {
   const baseURL = await getBaseURL({ email, password })
-  const { data } = await axios.post(`${baseURL}/store-login`, {
+  const { data } = await http.post(`${baseURL}/store-login`, {
     email,
     password,
   })

--- a/restaurant-kiosk/src/lib/http.ts
+++ b/restaurant-kiosk/src/lib/http.ts
@@ -1,0 +1,49 @@
+import axios from 'axios'
+import { modalController } from '@ionic/vue'
+import { useMainStore } from '../store/mainStore'
+import { defineComponent } from 'vue'
+
+const SessionExpired = defineComponent({
+  template: `
+    <div class="ion-padding">
+      <p>Session expired. Please log in again.</p>
+      <button id="session-expired-ok" @click="dismiss">OK</button>
+    </div>
+  `,
+  setup() {
+    const dismiss = () => {
+      void modalController.dismiss()
+    }
+    return { dismiss }
+  },
+})
+
+const http = axios.create()
+
+export async function unauthorizedInterceptor(error: any) {
+    const store = useMainStore()
+    {
+      if (typeof store.$reset === 'function') {
+        store.$reset()
+      } else {
+        store.token = null
+        store.baseURL = ''
+        store.locations = []
+        store.settings = null
+      }
+      const modal = await modalController.create({
+        component: SessionExpired,
+        backdropDismiss: false,
+      })
+      await modal.present()
+      await modal.onWillDismiss()
+      window.location.href = '/login'
+    }
+    return Promise.reject(error)
+  }
+
+http.interceptors.response.use((res) => res, unauthorizedInterceptor)
+
+export default http
+export { modalController }
+

--- a/restaurant-kiosk/src/store/mainStore.ts
+++ b/restaurant-kiosk/src/store/mainStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import axios from 'axios'
+import http from '../lib/http'
 import {
   bulkInsertItems,
   bulkInsertCustomers,
@@ -47,7 +47,7 @@ export const useMainStore = defineStore(
       const unsynced = await getUnsyncedOrders()
       for (const o of unsynced) {
         try {
-          await axios.post(`${baseURL.value}/place-order`, o, {
+          await http.post(`${baseURL.value}/place-order`, o, {
             headers: { Authorization: `Bearer ${token.value}` },
           })
           await markOrderSynced(o.id)
@@ -74,7 +74,7 @@ export const useMainStore = defineStore(
 
     async function login(email: string, password: string) {
       const url = await getBaseURL({ email, password })
-      const { data } = await axios.post(`${url}/store-login`, {
+      const { data } = await http.post(`${url}/store-login`, {
         email,
         password,
       })
@@ -89,7 +89,7 @@ export const useMainStore = defineStore(
       const loading = await loadingController.create({ message: 'Syncing items...' })
       await loading.present()
       try {
-        const { data } = await axios.get(`${baseURL.value}/items`, {
+        const { data } = await http.get(`${baseURL.value}/items`, {
           headers: { Authorization: `Bearer ${token.value}` },
         })
         const fetched: Item[] = data?.items || data || []
@@ -109,7 +109,7 @@ export const useMainStore = defineStore(
       const loading = await loadingController.create({ message: 'Syncing customers...' })
       await loading.present()
       try {
-        const { data } = await axios.get(`${baseURL.value}/customers`, {
+        const { data } = await http.get(`${baseURL.value}/customers`, {
           headers: { Authorization: `Bearer ${token.value}` },
         })
         const fetched: Customer[] = data?.customers || data || []
@@ -153,7 +153,7 @@ export const useMainStore = defineStore(
       }
       if (isOnline.value && baseURL.value && token.value) {
         try {
-          await axios.post(`${baseURL.value}/place-order`, order, {
+          await http.post(`${baseURL.value}/place-order`, order, {
             headers: { Authorization: `Bearer ${token.value}` },
           })
           await createOrder(order, 1)


### PR DESCRIPTION
## Summary
- add Axios instance with global unauthorized interceptor
- switch API and store to new HTTP client
- test that interceptor resets auth state

## Testing
- `npm test` *(fails: expected 't' to be null)*

------
https://chatgpt.com/codex/tasks/task_e_68ab519c007883248bf2e3298212ae87