### PR TITLE
Add sync view and router integration

### DIFF
--- a/restaurant-kiosk/src/App.vue
+++ b/restaurant-kiosk/src/App.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { IonApp } from '@ionic/vue'
-import HomeView from './views/HomeView.vue'
 </script>
 
 <template>
   <IonApp>
-    <HomeView />
+    <router-view />
   </IonApp>
 </template>

--- a/restaurant-kiosk/src/__tests__/SyncView.test.ts
+++ b/restaurant-kiosk/src/__tests__/SyncView.test.ts
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/vue'
+import { flushPromises } from '@vue/test-utils'
+import SyncView from '../views/SyncView.vue'
+import { vi } from 'vitest'
+
+const syncItems = vi.fn()
+const syncCustomers = vi.fn()
+const syncSettings = vi.fn()
+const push = vi.fn()
+
+vi.mock('../store/mainStore', () => ({
+  useMainStore: () => ({ syncItems, syncCustomers, syncSettings })
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push })
+}))
+
+vi.mock('../lib/errorHandler', () => ({ handleError: vi.fn() }))
+
+import { handleError } from '../lib/errorHandler'
+
+const stubs = {
+  IonPage: { name: 'IonPage', template: '<div><slot/></div>' },
+  IonContent: { name: 'IonContent', template: '<div><slot/></div>' }
+}
+
+describe('SyncView', () => {
+  beforeEach(() => {
+    syncItems.mockReset()
+    syncCustomers.mockReset()
+    syncSettings.mockReset()
+    push.mockReset()
+    handleError.mockReset()
+  })
+
+  it('continues syncing after failures', async () => {
+    syncItems.mockRejectedValue(new Error('fail'))
+    syncCustomers.mockResolvedValue(undefined)
+    syncSettings.mockResolvedValue(undefined)
+    render(SyncView, { global: { stubs } })
+    await flushPromises()
+    expect(syncItems).toHaveBeenCalled()
+    expect(syncCustomers).toHaveBeenCalled()
+    expect(syncSettings).toHaveBeenCalled()
+    expect(handleError).toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/home')
+  })
+
+  it('navigates home on success', async () => {
+    syncItems.mockResolvedValue(undefined)
+    syncCustomers.mockResolvedValue(undefined)
+    syncSettings.mockResolvedValue(undefined)
+    render(SyncView, { global: { stubs } })
+    await flushPromises()
+    expect(push).toHaveBeenCalledWith('/home')
+    expect(handleError).not.toHaveBeenCalled()
+  })
+})

--- a/restaurant-kiosk/src/__tests__/http.test.ts
+++ b/restaurant-kiosk/src/__tests__/http.test.ts
@@ -12,15 +12,16 @@ const mockedModal = {
 }
 
 describe('http interceptor', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    vi.clearAllMocks()
-    vi.spyOn(modalController, 'create').mockResolvedValue(mockedModal as any)
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { href: 'http://localhost/' },
+    beforeEach(() => {
+      setActivePinia(createPinia())
+      vi.clearAllMocks()
+      vi.spyOn(modalController, 'create').mockResolvedValue(mockedModal as any)
+      localStorage.clear()
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: { href: 'http://localhost/' },
+      })
     })
-  })
 
   it('resets store and redirects on 401', async () => {
     const store = useMainStore()

--- a/restaurant-kiosk/src/lib/http.ts
+++ b/restaurant-kiosk/src/lib/http.ts
@@ -21,26 +21,21 @@ const SessionExpired = defineComponent({
 const http = axios.create()
 
 export async function unauthorizedInterceptor(error: any) {
-    const store = useMainStore()
-    {
-      if (typeof store.$reset === 'function') {
-        store.$reset()
-      } else {
-        store.token = null
-        store.baseURL = ''
-        store.locations = []
-        store.settings = null
-      }
-      const modal = await modalController.create({
-        component: SessionExpired,
-        backdropDismiss: false,
-      })
-      await modal.present()
-      await modal.onWillDismiss()
-      window.location.href = '/login'
-    }
-    return Promise.reject(error)
-  }
+  const store = useMainStore()
+  store.token = null
+  store.baseURL = ''
+  store.locations = []
+  store.settings = null
+  localStorage.clear()
+  const modal = await modalController.create({
+    component: SessionExpired,
+    backdropDismiss: false,
+  })
+  await modal.present()
+  await modal.onWillDismiss()
+  window.location.href = '/login'
+  return Promise.reject(error)
+}
 
 http.interceptors.response.use((res) => res, unauthorizedInterceptor)
 

--- a/restaurant-kiosk/src/main.ts
+++ b/restaurant-kiosk/src/main.ts
@@ -8,6 +8,7 @@ import App from './App.vue'
 import { dbReady } from './lib/db'
 import { useMainStore } from './store/mainStore'
 import { MotionPlugin } from '@vueuse/motion'
+import router from './router'
 
 const app = createApp(App)
 const pinia = createPinia()
@@ -15,6 +16,7 @@ pinia.use(persisted)
 app.use(IonicVue)
 app.use(pinia)
 app.use(MotionPlugin)
+app.use(router)
 
 const mainStore = useMainStore()
 

--- a/restaurant-kiosk/src/router/index.ts
+++ b/restaurant-kiosk/src/router/index.ts
@@ -1,0 +1,19 @@
+import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
+import LoginView from '../views/LoginView.vue'
+import SyncView from '../views/SyncView.vue'
+import HomeView from '../views/HomeView.vue'
+
+const routes: RouteRecordRaw[] = [
+  { path: '/login', component: LoginView },
+  { path: '/sync', component: SyncView },
+  { path: '/manual-sync', component: SyncView },
+  { path: '/home', component: HomeView },
+  { path: '/', redirect: '/login' }
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+})
+
+export default router

--- a/restaurant-kiosk/src/store/mainStore.ts
+++ b/restaurant-kiosk/src/store/mainStore.ts
@@ -124,6 +124,23 @@ export const useMainStore = defineStore(
       }
     }
 
+    async function syncSettings() {
+      if (!baseURL.value || !token.value) return
+      const loading = await loadingController.create({ message: 'Syncing settings...' })
+      await loading.present()
+      try {
+        const { data } = await http.get(`${baseURL.value}/settings`, {
+          headers: { Authorization: `Bearer ${token.value}` },
+        })
+        settings.value = data
+        await showToast('Settings synced')
+      } catch (err) {
+        handleError(err)
+      } finally {
+        await loading.dismiss()
+      }
+    }
+
     function addToCart(item: Item) {
       const existing = cart.value.find((c) => c.item.id === item.id)
       if (existing) {
@@ -182,9 +199,10 @@ export const useMainStore = defineStore(
       cart,
       phone,
       login,
-      syncItems,
-      syncCustomers,
-      addToCart,
+        syncItems,
+        syncCustomers,
+        syncSettings,
+        addToCart,
       removeFromCart,
       placeOrder,
       clearCart,

--- a/restaurant-kiosk/src/views/LoginView.vue
+++ b/restaurant-kiosk/src/views/LoginView.vue
@@ -23,10 +23,8 @@ async function onLogin() {
   if (errors.value.email || errors.value.password) return
   loading.value = true
   try {
-    await store.login(email.value, password.value)
-    await store.syncItems()
-    await store.syncCustomers()
-    router.push('/home')
+      await store.login(email.value, password.value)
+      router.push('/sync')
   } catch (err) {
     handleError(err)
   } finally {

--- a/restaurant-kiosk/src/views/SyncView.vue
+++ b/restaurant-kiosk/src/views/SyncView.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { IonPage, IonContent } from '@ionic/vue'
+import { useRouter } from 'vue-router'
+import { useMainStore } from '../store/mainStore'
+import { handleError } from '../lib/errorHandler'
+
+const router = useRouter()
+const store = useMainStore()
+
+onMounted(async () => {
+  const syncTasks = [store.syncItems, store.syncCustomers, store.syncSettings].filter(Boolean)
+  for (const task of syncTasks) {
+    try {
+      await task()
+    } catch (err) {
+      handleError(err)
+    }
+  }
+  router.push('/home')
+})
+</script>
+
+<template>
+  <IonPage>
+    <IonContent class="ion-padding">
+      <p>Syncing...</p>
+    </IonContent>
+  </IonPage>
+</template>


### PR DESCRIPTION
## Summary
- integrate Vue Router with routes for login, sync, manual sync, and home
- add SyncView that runs data syncs sequentially with error handling and routes home on completion
- update login flow to redirect to sync screen
- add store syncSettings helper and tests ensuring sync flow resiliency
- ensure unauthorized responses clear auth state

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab56f9c89883249b83deaeb1c5ba40