### PR TITLE
feat: add manual sync view

### DIFF
--- a/restaurant-kiosk/src/__tests__/ManualSyncView.test.ts
+++ b/restaurant-kiosk/src/__tests__/ManualSyncView.test.ts
@@ -1,0 +1,61 @@
+import { render, fireEvent } from '@testing-library/vue'
+import { flushPromises } from '@vue/test-utils'
+import ManualSyncView from '../views/ManualSyncView.vue'
+import { vi } from 'vitest'
+
+const syncItems = vi.fn()
+const syncCustomers = vi.fn()
+const syncSettings = vi.fn()
+const syncOrders = vi.fn()
+
+vi.mock('../store/mainStore', () => ({
+  useMainStore: () => ({ syncItems, syncCustomers, syncSettings, syncOrders })
+}))
+
+vi.mock('../lib/errorHandler', () => ({ handleError: vi.fn() }))
+
+import { handleError } from '../lib/errorHandler'
+
+const stubs = {
+  IonPage: { name: 'IonPage', template: '<div><slot/></div>' },
+  IonContent: { name: 'IonContent', template: '<div><slot/></div>' },
+  IonButton: { name: 'IonButton', template: '<button @click="$emit(\'click\')"><slot/></button>' },
+  IonSpinner: { name: 'IonSpinner', template: '<span></span>' },
+}
+
+describe('ManualSyncView', () => {
+  beforeEach(() => {
+    syncItems.mockReset()
+    syncCustomers.mockReset()
+    syncSettings.mockReset()
+    syncOrders.mockReset()
+    handleError.mockReset()
+  })
+
+  it('invokes store methods on button click', async () => {
+    const { getByText } = render(ManualSyncView, { global: { stubs } })
+    await fireEvent.click(getByText('Sync Items'))
+    expect(syncItems).toHaveBeenCalled()
+    await fireEvent.click(getByText('Sync Customers'))
+    expect(syncCustomers).toHaveBeenCalled()
+    await fireEvent.click(getByText('Sync Settings'))
+    expect(syncSettings).toHaveBeenCalled()
+    await fireEvent.click(getByText('Sync Orders'))
+    expect(syncOrders).toHaveBeenCalled()
+  })
+
+  it('handles errors for each action', async () => {
+    syncItems.mockRejectedValueOnce(new Error('fail'))
+    syncCustomers.mockRejectedValueOnce(new Error('fail'))
+    syncSettings.mockRejectedValueOnce(new Error('fail'))
+    syncOrders.mockRejectedValueOnce(new Error('fail'))
+    const { getByText } = render(ManualSyncView, { global: { stubs } })
+    await fireEvent.click(getByText('Sync Items'))
+    await fireEvent.click(getByText('Sync Customers'))
+    await fireEvent.click(getByText('Sync Settings'))
+    await fireEvent.click(getByText('Sync Orders'))
+    await flushPromises()
+    expect(handleError).toHaveBeenCalledTimes(4)
+  })
+})
+

--- a/restaurant-kiosk/src/router/index.ts
+++ b/restaurant-kiosk/src/router/index.ts
@@ -2,11 +2,12 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import LoginView from '../views/LoginView.vue'
 import SyncView from '../views/SyncView.vue'
 import HomeView from '../views/HomeView.vue'
+import ManualSyncView from '../views/ManualSyncView.vue'
 
 const routes: RouteRecordRaw[] = [
   { path: '/login', component: LoginView },
   { path: '/sync', component: SyncView },
-  { path: '/manual-sync', component: SyncView },
+  { path: '/manual-sync', component: ManualSyncView },
   { path: '/home', component: HomeView },
   { path: '/', redirect: '/login' }
 ]

--- a/restaurant-kiosk/src/views/HomeView.vue
+++ b/restaurant-kiosk/src/views/HomeView.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { IonPage, IonContent } from '@ionic/vue'
+import { IonPage, IonContent, IonButton } from '@ionic/vue'
 import CategoryList from '../components/CategoryList.vue'
 import ItemGrid from '../components/ItemGrid.vue'
 import { useMainStore } from '../store/mainStore'
 import type { Item } from '../lib/db'
+import { useRouter } from 'vue-router'
 
 type ItemWithImage = Item & { image_link?: string; category_id?: string; category?: string }
 interface Category { id: string; name: string }
 
 const store = useMainStore()
 const selected = ref<string | null>(null)
+const router = useRouter()
 
 const categories = computed(() => (store.categories as Category[]) || [])
 const items = computed<ItemWithImage[]>(() => {
@@ -27,11 +29,18 @@ function handleSelect(id: string | null) {
 function handleAdd(item: ItemWithImage) {
   store.addToCart(item)
 }
+
+function goManualSync() {
+  router.push('/manual-sync')
+}
 </script>
 
 <template>
   <IonPage>
     <IonContent>
+      <div class="p-4">
+        <IonButton @click="goManualSync">Manual Sync</IonButton>
+      </div>
       <CategoryList
         :categories="categories"
         :selected="selected"

--- a/restaurant-kiosk/src/views/ManualSyncView.vue
+++ b/restaurant-kiosk/src/views/ManualSyncView.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { IonPage, IonContent, IonButton, IonSpinner } from '@ionic/vue'
+import { useMainStore } from '../store/mainStore'
+import { handleError } from '../lib/errorHandler'
+
+const store = useMainStore()
+
+const syncing = ref({
+  items: false,
+  customers: false,
+  settings: false,
+  orders: false,
+})
+
+async function run(key: 'items' | 'customers' | 'settings' | 'orders') {
+  syncing.value[key] = true
+  const map = {
+    items: store.syncItems,
+    customers: store.syncCustomers,
+    settings: store.syncSettings,
+    orders: store.syncOrders,
+  }
+  try {
+    await map[key]()
+  } catch (err) {
+    handleError(err)
+  } finally {
+    syncing.value[key] = false
+  }
+}
+</script>
+
+<template>
+  <IonPage>
+    <IonContent class="ion-padding flex flex-col gap-4">
+      <IonButton @click="run('items')" :disabled="syncing.items">
+        Sync Items
+        <IonSpinner v-if="syncing.items" slot="end" />
+      </IonButton>
+      <IonButton @click="run('customers')" :disabled="syncing.customers">
+        Sync Customers
+        <IonSpinner v-if="syncing.customers" slot="end" />
+      </IonButton>
+      <IonButton @click="run('settings')" :disabled="syncing.settings">
+        Sync Settings
+        <IonSpinner v-if="syncing.settings" slot="end" />
+      </IonButton>
+      <IonButton @click="run('orders')" :disabled="syncing.orders">
+        Sync Orders
+        <IonSpinner v-if="syncing.orders" slot="end" />
+      </IonButton>
+    </IonContent>
+  </IonPage>
+</template>
+


### PR DESCRIPTION
## Summary
- add manual sync view for items, customers, settings, and orders
- wire up /manual-sync route and navigation from home
- test manual sync actions and error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5b2f0f4c83249885c458a966c377