### PR TITLE
feat: add APK generation scripts and test

### DIFF
--- a/restaurant-kiosk/README.md
+++ b/restaurant-kiosk/README.md
@@ -3,3 +3,22 @@
 This template should help get you started developing with Vue 3 and TypeScript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
 
 Learn more about the recommended Project Setup and IDE Support in the [Vue Docs TypeScript Guide](https://vuejs.org/guide/typescript/overview.html#project-setup).
+
+## Generating Android APK
+
+Use the helper scripts in the repository root to check dependencies and build the Android application.
+
+### Unix/macOS
+```bash
+./scripts/generate-apk.sh --check   # verify required tools
+./scripts/generate-apk.sh           # interactive build or open Android Studio
+```
+
+### Windows
+```bat
+scripts\generate-apk.bat --check
+scripts\generate-apk.bat
+```
+
+The script will list detected tools and then prompt you to either run a CLI build (`npx cap build android`) or launch Android Studio (`npx cap open android`).
+

--- a/restaurant-kiosk/src/__tests__/generate-apk.test.ts
+++ b/restaurant-kiosk/src/__tests__/generate-apk.test.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+describe('generate-apk script', () => {
+  it('runs dependency checks with --check flag', () => {
+    const script = path.resolve(__dirname, '../../../scripts/generate-apk.sh');
+    const output = execSync(`${script} --check`, { encoding: 'utf8' });
+    expect(output).toMatch(/Node\.js/i);
+    expect(output).toMatch(/Android SDK/i);
+    expect(output).toMatch(/Android Studio/i);
+  });
+});

--- a/scripts/generate-apk.bat
+++ b/scripts/generate-apk.bat
@@ -1,0 +1,61 @@
+@echo off
+setlocal
+
+echo [INFO] Checking required tools
+
+call :check node "Node.js"
+call :check npm "npm"
+call :check java "Java"
+call :check gradle "Gradle"
+
+where sdkmanager >nul 2>nul
+if %errorlevel%==0 (
+  echo [INFO] Android SDK detected
+) else if defined ANDROID_HOME (
+  echo [INFO] Android SDK detected at %ANDROID_HOME%
+) else if defined ANDROID_SDK_ROOT (
+  echo [INFO] Android SDK detected at %ANDROID_SDK_ROOT%
+) else (
+  echo [WARN] Android SDK not found
+)
+
+where studio64 >nul 2>nul
+if %errorlevel%==0 (
+  echo [INFO] Android Studio detected
+) else (
+  where studio >nul 2>nul
+  if %errorlevel%==0 (
+    echo [INFO] Android Studio detected
+  ) else (
+    echo [WARN] Android Studio not found
+  )
+)
+
+if "%1"=="--check" goto :EOF
+
+echo Select build option:
+echo 1^) CLI build (npx cap build android)
+echo 2^) Launch Android Studio (npx cap open android)
+set /p choice=Enter choice [1/2]: 
+
+if "%choice%"=="1" (
+  echo [INFO] Running CLI build (npx cap build android)
+  npx cap build android
+) else if "%choice%"=="2" (
+  echo [INFO] Opening Android Studio (npx cap open android)
+  npx cap open android
+) else (
+  echo [WARN] Invalid choice: %choice%
+  exit /b 1
+)
+
+goto :EOF
+
+:check
+where %1 >nul 2>nul
+if %errorlevel%==0 (
+  for /f "delims=" %%i in ('where %1') do echo [INFO] %2 detected (%%i)
+) else (
+  echo [WARN] %2 not found
+)
+exit /b 0

--- a/scripts/generate-apk.sh
+++ b/scripts/generate-apk.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+log() {
+  echo "[INFO] $1"
+}
+
+warn() {
+  echo "[WARN] $1"
+}
+
+check() {
+  local cmd="$1"
+  local name="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    log "$name detected ($(command -v $cmd))"
+  else
+    warn "$name not found"
+  fi
+}
+
+log "Checking required tools"
+
+check node "Node.js"
+check npm "npm"
+check java "Java"
+check gradle "Gradle"
+
+if command -v sdkmanager >/dev/null 2>&1 || [ -n "$ANDROID_HOME" ] || [ -n "$ANDROID_SDK_ROOT" ]; then
+  log "Android SDK detected"
+else
+  warn "Android SDK not found"
+fi
+
+if command -v studio >/dev/null 2>&1 || command -v android-studio >/dev/null 2>&1 || command -v studio.sh >/dev/null 2>&1; then
+  log "Android Studio detected"
+else
+  warn "Android Studio not found"
+fi
+
+if [[ "$1" == "--check" ]]; then
+  log "Dependency check complete"
+  exit 0
+fi
+
+echo "Select build option:"
+echo "1) CLI build (npx cap build android)"
+echo "2) Launch Android Studio (npx cap open android)"
+read -r -p "Enter choice [1/2]: " choice
+
+if [[ "$choice" == "1" ]]; then
+  log "Running CLI build (npx cap build android)"
+  npx cap build android
+elif [[ "$choice" == "2" ]]; then
+  log "Opening Android Studio (npx cap open android)"
+  npx cap open android
+else
+  warn "Invalid choice: $choice"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add scripts to check Android build dependencies and run CLI build or open Android Studio
- document APK generation workflow
- test dependency checks via `--check` dry run

## Testing
- `cd restaurant-kiosk && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab5f8507fc83249a0351c9c01aab99