### PR TITLE
Add settings view with factory reset option

### DIFF
--- a/restaurant-kiosk/src/__tests__/SettingsView.test.ts
+++ b/restaurant-kiosk/src/__tests__/SettingsView.test.ts
@@ -1,0 +1,61 @@
+import { render, fireEvent } from '@testing-library/vue'
+import SettingsView from '../views/SettingsView.vue'
+import { vi } from 'vitest'
+
+const factoryReset = vi.fn()
+
+vi.mock('../store/mainStore', () => ({
+  useMainStore: () => ({ factoryReset }),
+}))
+
+const push = vi.fn()
+
+const stubs = {
+  IonPage: { name: 'IonPage', template: '<div><slot/></div>' },
+  IonContent: { name: 'IonContent', template: '<div><slot/></div>' },
+  IonInput: {
+    name: 'IonInput',
+    props: ['modelValue', 'type', 'label', 'labelPlacement'],
+    emits: ['update:modelValue'],
+    template:
+      '<input :type="type" :value="modelValue" :placeholder="label" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+  },
+  IonButton: {
+    name: 'IonButton',
+    template: '<button @click="$emit(\'click\')"><slot/></button>',
+  },
+}
+
+describe('SettingsView', () => {
+  beforeEach(() => {
+    factoryReset.mockReset()
+    push.mockReset()
+    localStorage.clear()
+  })
+
+  it('incorrect password does nothing', async () => {
+    const { getByPlaceholderText, getByText } = render(SettingsView, {
+      global: { stubs },
+    })
+    await fireEvent.update(getByPlaceholderText('Password'), 'wrong')
+    await fireEvent.click(getByText('Factory Reset'))
+    expect(factoryReset).not.toHaveBeenCalled()
+  })
+
+  it('correct password clears storage and navigates to login', async () => {
+    factoryReset.mockImplementation(() => {
+      localStorage.clear()
+      push('/login')
+    })
+    localStorage.setItem('foo', 'bar')
+    const { getByPlaceholderText, getByText } = render(SettingsView, {
+      global: { stubs },
+    })
+    await fireEvent.update(getByPlaceholderText('Password'), 'jakatest')
+    await fireEvent.click(getByText('Factory Reset'))
+    expect(factoryReset).toHaveBeenCalled()
+    expect(localStorage.getItem('foo')).toBeNull()
+    expect(push).toHaveBeenCalledWith('/login')
+  })
+})
+

--- a/restaurant-kiosk/src/__tests__/mainStore.test.ts
+++ b/restaurant-kiosk/src/__tests__/mainStore.test.ts
@@ -33,6 +33,10 @@ vi.mock('@ionic/vue', () => ({
   },
 }))
 
+vi.mock('@capacitor-community/sqlite', () => ({
+  CapacitorSQLite: { deleteDatabase: vi.fn() },
+}))
+
 import http from '../lib/http'
 import * as api from '../lib/api'
 import * as db from '../lib/db'

--- a/restaurant-kiosk/src/router/index.ts
+++ b/restaurant-kiosk/src/router/index.ts
@@ -3,12 +3,14 @@ import LoginView from '../views/LoginView.vue'
 import SyncView from '../views/SyncView.vue'
 import HomeView from '../views/HomeView.vue'
 import ManualSyncView from '../views/ManualSyncView.vue'
+import SettingsView from '../views/SettingsView.vue'
 
 const routes: RouteRecordRaw[] = [
   { path: '/login', component: LoginView },
   { path: '/sync', component: SyncView },
   { path: '/manual-sync', component: ManualSyncView },
   { path: '/home', component: HomeView },
+  { path: '/settings', component: SettingsView },
   { path: '/', redirect: '/login' }
 ]
 

--- a/restaurant-kiosk/src/views/SettingsView.vue
+++ b/restaurant-kiosk/src/views/SettingsView.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { IonPage, IonContent, IonInput, IonButton } from '@ionic/vue'
+import { useMainStore } from '../store/mainStore'
+
+const password = ref('')
+const store = useMainStore()
+
+async function onFactoryReset() {
+  if (password.value === 'jakatest') {
+    await store.factoryReset()
+  }
+}
+</script>
+
+<template>
+  <IonPage>
+    <IonContent class="ion-padding">
+      <div class="flex flex-col gap-4 max-w-md mx-auto">
+        <IonInput
+          v-model="password"
+          type="password"
+          label="Password"
+          label-placement="floating"
+        />
+        <IonButton expand="block" class="py-4" @click="onFactoryReset">
+          Factory Reset
+        </IonButton>
+      </div>
+    </IonContent>
+  </IonPage>
+</template>
+


### PR DESCRIPTION
## Summary
- add Settings view with password-protected factory reset
- wire up `/settings` route and store-level factoryReset logic
- test settings workflow and stub sqlite in store tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab6019003483249e05b983c5fd9aee