### PR TITLE
Improve kiosk UI styling and tests

### DIFF
--- a/restaurant-kiosk/src/__tests__/HomeView.ui.test.ts
+++ b/restaurant-kiosk/src/__tests__/HomeView.ui.test.ts
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/vue'
+import HomeView from '../views/HomeView.vue'
+import { vi } from 'vitest'
+
+vi.mock('../store/mainStore', () => ({
+  useMainStore: () => ({
+    categories: [{ id: '1', name: 'Cat' }],
+    items: [{ id: '1', name: 'Item', price: 1, category_id: '1' }],
+    addToCart: vi.fn(),
+  }),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const stubs = {
+  IonPage: { name: 'IonPage', template: '<div v-bind="$attrs"><slot/></div>' },
+  IonContent: { name: 'IonContent', template: '<div v-bind="$attrs"><slot/></div>' },
+  IonButton: { name: 'IonButton', template: '<button v-bind="$attrs"><slot/></button>' },
+  IonSegment: { name: 'IonSegment', template: '<div v-bind="$attrs"><slot/></div>' },
+  IonSegmentButton: {
+    name: 'IonSegmentButton',
+    props: ['value'],
+    template: '<button v-bind="$attrs" :value="value"><slot/></button>',
+  },
+  IonLabel: { name: 'IonLabel', template: '<span v-bind="$attrs"><slot/></span>' },
+  IonGrid: { name: 'IonGrid', template: '<div v-bind="$attrs"><slot/></div>' },
+  IonRow: { name: 'IonRow', template: '<div v-bind="$attrs"><slot/></div>' },
+  IonCol: { name: 'IonCol', template: '<div v-bind="$attrs"><slot/></div>' },
+  ItemCard: { name: 'ItemCard', props: ['item'], template: '<div />' },
+}
+
+describe('HomeView kiosk UI', () => {
+  it('applies kiosk-specific classes', () => {
+    const { container } = render(HomeView, { global: { stubs } })
+    expect(container.querySelector('.kiosk-theme')).toBeTruthy()
+    expect(container.querySelector('.btn-lg')).toBeTruthy()
+    expect(container.querySelector('.text-xl')).toBeTruthy()
+  })
+})

--- a/restaurant-kiosk/src/components/CategoryList.vue
+++ b/restaurant-kiosk/src/components/CategoryList.vue
@@ -18,20 +18,24 @@ function onChange(ev: CustomEvent) {
     :value="props.selected || ''"
     @ionChange="onChange"
     scrollable
-    class="px-2 py-4"
+    class="px-4 py-6 flex gap-4"
     aria-label="Categories"
   >
-    <IonSegmentButton value="" class="min-h-14 px-4" aria-label="All categories">
-      <IonLabel class="text-base">All</IonLabel>
+    <IonSegmentButton
+      value=""
+      class="btn-lg bg-red-500 text-white"
+      aria-label="All categories"
+    >
+      <IonLabel class="text-xl font-semibold">All</IonLabel>
     </IonSegmentButton>
     <IonSegmentButton
       v-for="cat in props.categories"
       :key="cat.id"
       :value="cat.id"
-      class="min-h-14 px-4"
+      class="btn-lg bg-red-500 text-white"
       :aria-label="cat.name"
     >
-      <IonLabel class="text-base">{{ cat.name }}</IonLabel>
+      <IonLabel class="text-xl font-semibold">{{ cat.name }}</IonLabel>
     </IonSegmentButton>
   </IonSegment>
 </template>

--- a/restaurant-kiosk/src/components/ItemGrid.vue
+++ b/restaurant-kiosk/src/components/ItemGrid.vue
@@ -15,8 +15,8 @@ function handleAdd(item: ItemWithImage) {
 </script>
 
 <template>
-  <IonGrid>
-    <IonRow role="list">
+  <IonGrid class="p-4">
+    <IonRow role="list" class="gap-4">
       <IonCol
         v-for="item in props.items"
         :key="item.id"
@@ -26,7 +26,7 @@ function handleAdd(item: ItemWithImage) {
         size-lg="3"
         role="listitem"
         :aria-label="item.name"
-        class="p-2"
+        class="p-4"
       >
         <ItemCard :item="item" @add="handleAdd" />
       </IonCol>

--- a/restaurant-kiosk/src/main.css
+++ b/restaurant-kiosk/src/main.css
@@ -1,3 +1,13 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .btn-lg {
+    @apply px-6 py-4 rounded-lg shadow-md;
+  }
+
+  .kiosk-theme {
+    @apply bg-yellow-100 text-gray-900;
+  }
+}

--- a/restaurant-kiosk/src/views/HomeView.vue
+++ b/restaurant-kiosk/src/views/HomeView.vue
@@ -36,10 +36,15 @@ function goManualSync() {
 </script>
 
 <template>
-  <IonPage>
-    <IonContent>
-      <div class="p-4">
-        <IonButton @click="goManualSync">Manual Sync</IonButton>
+  <IonPage class="kiosk-theme">
+    <IonContent class="p-4 space-y-6">
+      <div class="flex justify-end">
+        <IonButton
+          class="btn-lg text-xl bg-blue-600 text-white"
+          @click="goManualSync"
+        >
+          Manual Sync
+        </IonButton>
       </div>
       <CategoryList
         :categories="categories"


### PR DESCRIPTION
## Summary
- enlarge buttons and spacing with high contrast kiosk theme
- add playful kiosk palette using `btn-lg` and `kiosk-theme` classes
- test for kiosk-specific classes in HomeView

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a46c91c83248891aa8d99070fd8