### PR TITLE
fix: automate android build

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.jaka.kiosk',
   appName: 'restaurant-kiosk',
-  webDir: 'public'
+  webDir: 'dist'
 };
 
 export default config;

--- a/scripts/generate-apk.sh
+++ b/scripts/generate-apk.sh
@@ -48,9 +48,17 @@ echo "2) Launch Android Studio (npx cap open android)"
 read -r -p "Enter choice [1/2]: " choice
 
 if [[ "$choice" == "1" ]]; then
+  log "Building web assets (npm run build)"
+  npm run build || exit 1
+  log "Syncing Capacitor Android project (npx cap sync android)"
+  npx cap sync android || exit 1
   log "Running CLI build (npx cap build android)"
   npx cap build android
 elif [[ "$choice" == "2" ]]; then
+  log "Building web assets (npm run build)"
+  npm run build || exit 1
+  log "Syncing Capacitor Android project (npx cap sync android)"
+  npx cap sync android || exit 1
   log "Opening Android Studio (npx cap open android)"
   npx cap open android
 else

--- a/src/__tests__/generate-apk.test.ts
+++ b/src/__tests__/generate-apk.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 
 describe('generate-apk script', () => {
   it('runs dependency checks with --check flag', () => {
-    const script = path.resolve(__dirname, '../../../scripts/generate-apk.sh');
+    const script = path.resolve(__dirname, '../../scripts/generate-apk.sh');
     const output = execSync(`${script} --check`, { encoding: 'utf8' });
     expect(output).toMatch(/Node\.js/i);
     expect(output).toMatch(/Android SDK/i);

--- a/src/store/mainStore.ts
+++ b/src/store/mainStore.ts
@@ -198,7 +198,7 @@ export const useMainStore = defineStore(
     function filterItems(category: string | null) {
       if (!category) return items.value
       return items.value.filter(
-        (i) => i.category_id === category || (i as any).category === category
+        (i: any) => i.category_id === category || i.category === category
       )
     }
 
@@ -240,7 +240,7 @@ export const useMainStore = defineStore(
 
     async function factoryReset() {
       try {
-        await CapacitorSQLite.deleteDatabase({ database: 'app_db', version: 1 })
+        await CapacitorSQLite.deleteDatabase({ database: 'app_db' })
       } catch {}
 
       try {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,5 +11,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "exclude": ["src/__tests__/**"]
 }


### PR DESCRIPTION
## Summary
- point capacitor build to dist output
- run web build and sync before Android build
- exclude test files from app TypeScript config and clean up store types

## Testing
- `npx vitest run`
- `scripts/generate-apk.sh <<'EOF'
1
EOF` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab860a037c8324b202bfc381a51103